### PR TITLE
Add optional CUDA stream

### DIFF
--- a/neighbor/LBVH.cc
+++ b/neighbor/LBVH.cc
@@ -10,11 +10,13 @@ namespace neighbor
 
 /*!
  * \param exec_conf HOOMD-blue execution configuration
+ * \param stream CUDA stream for kernel execution.
  *
  * The constructor defers memory initialization to the first call to ::build.
  */
-LBVH::LBVH(std::shared_ptr<const ExecutionConfiguration> exec_conf)
-    : m_exec_conf(exec_conf), m_root(gpu::LBVHSentinel), m_N(0), m_N_internal(0), m_N_nodes(0)
+LBVH::LBVH(std::shared_ptr<const ExecutionConfiguration> exec_conf, cudaStream_t stream)
+    : m_exec_conf(exec_conf), m_stream(stream),
+      m_root(gpu::LBVHSentinel), m_N(0), m_N_internal(0), m_N_nodes(0)
     {
     m_exec_conf->msg->notice(4) << "Constructing LBVH" << std::endl;
 

--- a/neighbor/LBVHTraverser.cu
+++ b/neighbor/LBVHTraverser.cu
@@ -19,7 +19,8 @@ template void lbvh_compress_ropes(LBVHCompressedData ctree,
                                   const LBVHData tree,
                                   unsigned int N_internal,
                                   unsigned int N_nodes,
-                                  unsigned int block_size);
+                                  unsigned int block_size,
+                                  cudaStream_t stream);
 
 // template declaration for compressing with map transformation of primitives
 template void lbvh_compress_ropes(LBVHCompressedData ctree,
@@ -27,7 +28,8 @@ template void lbvh_compress_ropes(LBVHCompressedData ctree,
                                   const LBVHData tree,
                                   unsigned int N_internal,
                                   unsigned int N_nodes,
-                                  unsigned int block_size);
+                                  unsigned int block_size,
+                                  cudaStream_t stream);
 
 // template declaration to count neighbors
 template void lbvh_traverse_ropes(CountNeighborsOp& out,
@@ -35,7 +37,8 @@ template void lbvh_traverse_ropes(CountNeighborsOp& out,
                                   const SphereQueryOp& query,
                                   const Scalar3 *d_images,
                                   unsigned int Nimages,
-                                  unsigned int block_size);
+                                  unsigned int block_size,
+                                  cudaStream_t stream);
 
 // template declaration to generate neighbor list
 template void lbvh_traverse_ropes(NeighborListOp& out,
@@ -43,7 +46,8 @@ template void lbvh_traverse_ropes(NeighborListOp& out,
                                   const SphereQueryOp& query,
                                   const Scalar3 *d_images,
                                   unsigned int Nimages,
-                                  unsigned int block_size);
+                                  unsigned int block_size,
+                                  cudaStream_t stream);
 
 } // end namespace gpu
 } // end namespace neighbor


### PR DESCRIPTION
It may turn out to be helpful to be able to specify the CUDA stream for some kernels. If none is specified, functions gracefully fall back on the default stream. It is unclear if there are any performance benefits from using a stream, or if there are any implicit synchronizations with the default stream from HOOMD's low-level classes.