### PR TITLE
Use similar API for UniformGrid as for LBVH

### DIFF
--- a/neighbor/BoundingVolumes.h
+++ b/neighbor/BoundingVolumes.h
@@ -90,6 +90,11 @@ struct BoundingBox
                  hi.z < box.lo.z || lo.z > box.hi.z);
         }
 
+    HOSTDEVICE BoundingBox asBox() const
+        {
+        return *this;
+        }
+
     float3 lo;  //!< Lower bound of box
     float3 hi;  //!< Upper bound of box
     };
@@ -168,6 +173,14 @@ struct BoundingSphere
         const float dr2 = __fmaf_rd(dr.x, dr.x, __fmaf_rd(dr.y, dr.y, __fmul_rd(dr.z,dr.z)));
 
         return (dr2 <= Rsq);
+        }
+
+    DEVICE BoundingBox asBox() const
+        {
+        const float R = __fsqrt_ru(Rsq);
+        const float3 lo = make_float3(__fsub_rd(origin.x,R),__fsub_rd(origin.y,R),__fsub_rd(origin.z,R));
+        const float3 hi = make_float3(__fadd_ru(origin.x,R),__fadd_ru(origin.y,R),__fadd_ru(origin.z,R));
+        return BoundingBox(lo,hi);
         }
     #endif
 

--- a/neighbor/UniformGrid.cu
+++ b/neighbor/UniformGrid.cu
@@ -221,6 +221,9 @@ uchar2 uniform_grid_sort_points(void *d_tmp,
     uchar2 swap = make_uchar2(0,0);
     if (d_tmp != NULL)
         {
+        // synchronize first to make sure active selection is known
+        cudaStreamSynchronize(stream);
+
         // mark that the gpu arrays should be flipped if the final result is not in the sorted array (1)
         swap.x = (d_keys.selector == 0);
         swap.y = (d_vals.selector == 0);

--- a/neighbor/UniformGrid.cu
+++ b/neighbor/UniformGrid.cu
@@ -30,18 +30,15 @@ namespace kernel
  */
 __global__ void uniform_grid_bin_points(unsigned int *d_cells,
                                         unsigned int *d_primitives,
-                                        const Scalar4 *d_points,
-                                        const UniformGridData grid,
-                                        const unsigned int N)
+                                        const GridPointOp insert,
+                                        const UniformGridData grid)
     {
     // one thread per point
     const unsigned int idx = blockDim.x * blockIdx.x + threadIdx.x;
-    if (idx >= N)
+    if (idx >= insert.size())
         return;
 
-    const Scalar4 point = d_points[idx];
-    const Scalar3 r = make_scalar3(point.x, point.y, point.z);
-
+    const Scalar3 r = insert.get(idx);
     const int3 bin = grid.toCell(r);
 
     d_cells[idx] = grid.indexer(bin.x, bin.y, bin.z);
@@ -59,22 +56,19 @@ __global__ void uniform_grid_bin_points(unsigned int *d_cells,
  * w component of the sorted points stores the original index of the point
  * for cache-friendly loads by traversal schemes.
  */
-__global__ void uniform_grid_sort_points(Scalar4 *d_sorted_points,
-                                         const Scalar4 *d_points,
-                                         const unsigned int *d_sorted_indexes,
-                                         const unsigned int N)
+__global__ void uniform_grid_move_points(Scalar4 *d_sorted_points,
+                                         const GridPointOp insert,
+                                         const unsigned int *d_sorted_indexes)
     {
     // one thread per point
     const unsigned int idx = blockDim.x * blockIdx.x + threadIdx.x;
-    if (idx >= N)
+    if (idx >= insert.size())
         return;
 
     const unsigned int tag = d_sorted_indexes[idx];
-    Scalar4 point = d_points[tag];
-    point.w = __int_as_scalar(tag);
+    const Scalar3 r = insert.get(tag);
 
-
-    d_sorted_points[idx] = point;
+    d_sorted_points[idx] = make_scalar4(r.x, r.y, r.z, __int_as_scalar(tag));
     }
 
 //! Kernel to find the first point and last point in each bin.
@@ -166,10 +160,10 @@ __global__ void uniform_grid_size_cells(unsigned int *d_size,
  */
 void uniform_grid_bin_points(unsigned int *d_cells,
                              unsigned int *d_primitives,
-                             const Scalar4 *d_points,
+                             const GridPointOp& insert,
                              const UniformGridData grid,
-                             const unsigned int N,
-                             const unsigned int block_size)
+                             const unsigned int block_size,
+                             cudaStream_t stream)
     {
     // clamp block size
     static unsigned int max_block_size = UINT_MAX;
@@ -181,8 +175,8 @@ void uniform_grid_bin_points(unsigned int *d_cells,
         }
     const unsigned int run_block_size = (block_size < max_block_size) ? block_size : max_block_size;
 
-    const unsigned int num_blocks = (N + run_block_size - 1)/run_block_size;
-    kernel::uniform_grid_bin_points<<<num_blocks, run_block_size>>>(d_cells, d_primitives, d_points, grid, N);
+    const unsigned int num_blocks = (insert.size() + run_block_size - 1)/run_block_size;
+    kernel::uniform_grid_bin_points<<<num_blocks, run_block_size, 0, stream>>>(d_cells, d_primitives, insert, grid);
     }
 
 /*!
@@ -215,15 +209,14 @@ uchar2 uniform_grid_sort_points(void *d_tmp,
                                 unsigned int *d_sorted_cells,
                                 unsigned int *d_indexes,
                                 unsigned int *d_sorted_indexes,
-                                const Scalar4 *d_points,
-                                Scalar4 *d_sorted_points,
-                                const unsigned int N)
+                                const unsigned int N,
+                                cudaStream_t stream)
     {
 
     cub::DoubleBuffer<unsigned int> d_keys(d_cells, d_sorted_cells);
     cub::DoubleBuffer<unsigned int> d_vals(d_indexes, d_sorted_indexes);
 
-    cub::DeviceRadixSort::SortPairs(d_tmp, tmp_bytes, d_keys, d_vals, N);
+    cub::DeviceRadixSort::SortPairs(d_tmp, tmp_bytes, d_keys, d_vals, N, 0, 8*sizeof(unsigned int), stream);
 
     uchar2 swap = make_uchar2(0,0);
     if (d_tmp != NULL)
@@ -231,13 +224,28 @@ uchar2 uniform_grid_sort_points(void *d_tmp,
         // mark that the gpu arrays should be flipped if the final result is not in the sorted array (1)
         swap.x = (d_keys.selector == 0);
         swap.y = (d_vals.selector == 0);
-
-        // sort the points
-        const unsigned int block_size = 128;
-        const unsigned int num_blocks = (N + block_size - 1)/block_size;
-        kernel::uniform_grid_sort_points<<<num_blocks, block_size>>>(d_sorted_points, d_points, d_vals.Current(), N);
         }
     return swap;
+    }
+
+void uniform_grid_move_points(Scalar4 *d_sorted_points,
+                              const GridPointOp& insert,
+                              const unsigned int *d_sorted_indexes,
+                              const unsigned int block_size,
+                              cudaStream_t stream)
+    {
+    // clamp block size
+    static unsigned int max_block_size = UINT_MAX;
+    if (max_block_size == UINT_MAX)
+        {
+        cudaFuncAttributes attr;
+        cudaFuncGetAttributes(&attr, (const void*)kernel::uniform_grid_move_points);
+        max_block_size = attr.maxThreadsPerBlock;
+        }
+    const unsigned int run_block_size = (block_size < max_block_size) ? block_size : max_block_size;
+
+    const unsigned int num_blocks = (insert.size() + run_block_size - 1)/run_block_size;
+    kernel::uniform_grid_move_points<<<num_blocks, run_block_size, 0, stream>>>(d_sorted_points, insert, d_sorted_indexes);
     }
 
 /*!
@@ -256,11 +264,12 @@ void uniform_grid_find_cells(unsigned int *d_first,
                              const unsigned int *d_cells,
                              const unsigned int N,
                              const unsigned int Ncells,
-                             const unsigned int block_size)
+                             const unsigned int block_size,
+                             cudaStream_t stream)
     {
     // initially, fill all cells as empty
-    thrust::fill(thrust::device, d_first, d_first+Ncells, UniformGridSentinel);
-    cudaMemset(d_size, 0, sizeof(unsigned int)*Ncells);
+    thrust::fill(thrust::cuda::par.on(stream), d_first, d_first+Ncells, UniformGridSentinel);
+    cudaMemsetAsync(d_size, 0, sizeof(unsigned int)*Ncells, stream);
 
     // get the range of primitives covered by each cell
         {
@@ -275,7 +284,7 @@ void uniform_grid_find_cells(unsigned int *d_first,
         const unsigned int run_block_size = (block_size < max_block_size_find) ? block_size : max_block_size_find;
 
         const unsigned int num_blocks = (N + run_block_size - 1)/run_block_size;
-        kernel::uniform_grid_find_ends<<<num_blocks, run_block_size>>>(d_first, d_size, d_cells, N);
+        kernel::uniform_grid_find_ends<<<num_blocks, run_block_size, 0, stream>>>(d_first, d_size, d_cells, N);
         }
 
     // compute the number of primitives in each cell
@@ -291,9 +300,8 @@ void uniform_grid_find_cells(unsigned int *d_first,
         const unsigned int run_block_size = (block_size < max_block_size_size) ? block_size : max_block_size_size;
 
         const unsigned int num_blocks = (Ncells + run_block_size - 1)/run_block_size;
-        kernel::uniform_grid_size_cells<<<num_blocks, run_block_size>>>(d_size, d_first, Ncells);
+        kernel::uniform_grid_size_cells<<<num_blocks, run_block_size, 0, stream>>>(d_size, d_first, Ncells);
         }
     }
-
 } // end namespace gpu
 } // end namespace neighbor

--- a/neighbor/UniformGridTraverser.cc
+++ b/neighbor/UniformGridTraverser.cc
@@ -4,160 +4,22 @@
 // Maintainer: mphoward
 
 #include "UniformGridTraverser.h"
-#include "UniformGridTraverser.cuh"
+#include "OutputOps.h"
+#include "QueryOps.h"
 
 namespace neighbor
 {
 
-/*!
- * \param exec_conf HOOMD-blue execution configuration.
- */
-UniformGridTraverser::UniformGridTraverser(std::shared_ptr<const ExecutionConfiguration> exec_conf)
-    : m_exec_conf(exec_conf), m_threads(1), m_num_stencil(0)
-    {
-    m_exec_conf->msg->notice(4) << "Constructing UniformGridTraverser" << std::endl;
+template void UniformGridTraverser::traverse(CountNeighborsOp&,
+                                             const SphereQueryOp&,
+                                             const UniformGrid&,
+                                             const GlobalArray<Scalar3>&,
+                                             cudaStream_t);
 
-    m_tune_traverse.reset(new Autotuner(32, 1024, 32, 5, 100000, "grid_traverse", m_exec_conf));
-
-    m_stencil_dim = make_uint3(0,0,0);
-    }
-
-UniformGridTraverser::~UniformGridTraverser()
-    {
-    m_exec_conf->msg->notice(4) << "Destroying UniformGridTraverser" << std::endl;
-    }
-
-/*!
- * \param out Number of overlaps per sphere.
- * \param spheres Test spheres.
- * \param N Number of test spheres.
- * \param grid UniformGrid to traverse.
- * \param box HOOMD-blue BoxDim corresponding giving the periodicity of the system.
- *
- * The format for a \a sphere is (x,y,z,R), where R is the radius of the sphere.
- *
- * The caller must ensure that all \a spheres lie within the bounds of the \a grid, or
- * traversal will produce incorrect results.
- */
-void UniformGridTraverser::traverse(const GlobalArray<unsigned int>& out,
-                                    const GlobalArray<Scalar4> spheres,
-                                    unsigned int N,
-                                    const UniformGrid& grid,
-                                    const BoxDim& box)
-    {
-    // box must be periodic in all directions
-    if (!box.getPeriodic().x || !box.getPeriodic().y || !box.getPeriodic().z)
-        {
-        m_exec_conf->msg->error() << "Box must be periodic in all dimensions for now" << std::endl;
-        throw std::runtime_error("Box must be periodic");
-        }
-
-    // create stencil if grid dimension has changed
-    const uint3 dim = grid.getDimensions();
-    if (dim.x != m_stencil_dim.x || dim.y != m_stencil_dim.y || dim.z != m_stencil_dim.z)
-        {
-        createStencil(grid);
-        m_stencil_dim = grid.getDimensions();
-        }
-
-    // counts
-    ArrayHandle<unsigned int> d_out(out, access_location::device, access_mode::overwrite);
-
-    // primitives
-    ArrayHandle<Scalar4> d_spheres(spheres, access_location::device, access_mode::read);
-
-    // cell list data
-    ArrayHandle<unsigned int> d_first(grid.getFirsts(), access_location::device, access_mode::read);
-    ArrayHandle<unsigned int> d_size(grid.getSizes(), access_location::device, access_mode::read);
-    ArrayHandle<Scalar4> d_primitives(grid.getPoints(), access_location::device, access_mode::read);
-    ArrayHandle<int3> d_stencil(m_stencil, access_location::device, access_mode::read);
-    // uniform grid data
-    gpu::UniformGridData g;
-    g.first = d_first.data;
-    g.size = d_size.data;
-    g.point = d_primitives.data;
-    g.lo = grid.getLo();
-    g.L = grid.getL();
-    g.width = grid.getWidth();
-    g.indexer = grid.getIndexer();
-
-    m_tune_traverse->begin();
-    gpu::uniform_grid_traverse(d_out.data,
-                               // test point traversal
-                               d_spheres.data,
-                               g,
-                               d_stencil.data,
-                               m_num_stencil,
-                               box,
-                               // block config
-                               N,
-                               m_threads,
-                               m_tune_traverse->getParam());
-    if (m_exec_conf->isCUDAErrorCheckingEnabled()) CHECK_CUDA_ERROR();
-    m_tune_traverse->end();
-    }
-
-/*!
- * \param grid UniformGrid to create traversal stencil for
- *
- * The standard 27-point stencil is constructed, while ensuring that
- * small numbers of cells in each dimension are handled correctly.
- */
-void UniformGridTraverser::createStencil(const UniformGrid& grid)
-    {
-    // size stencil assuming standard 27 cells (if at least 3 cells per dim) and allocate
-    const uint3 dim = grid.getDimensions();
-    const char3 min = make_char3(-(dim.x > 2), -(dim.y > 2), -(dim.z > 2));
-    const char3 max = make_char3( (dim.x > 1),  (dim.y > 1),  (dim.z > 1));
-    m_num_stencil = (max.x-min.x+1)*(max.y-min.y+1)*(max.z-min.z+1);
-    if (m_stencil.getNumElements() < m_num_stencil)
-        {
-        GlobalArray<int3> tmp(m_num_stencil, m_exec_conf);
-        m_stencil.swap(tmp);
-        }
-
-    // push stencils into the list
-    unsigned int idx = 0;
-    ArrayHandle<int3> h_stencil(m_stencil, access_location::host, access_mode::overwrite);
-    for (char i=min.x; i <= max.x; ++i)
-        {
-        for (char j=min.y; j <= max.y; ++j)
-            {
-            for (char k=min.z; k <= max.z; ++k)
-                {
-                h_stencil.data[idx++] = make_int3(i, j, k);
-                }
-            }
-        }
-    }
-
-/*!
- * \param threads Number of threads per traversal sphere.
- *
- * The \a threads must be a power of 2 that is greater than or equal to
- * 1 and less than or equal to 32. The reason for this restriction is that
- * the CUDA kernels use warp scan/reduction to process the particles, and so
- * the number of threads is set by the CUDA warp size.
- */
-void UniformGridTraverser::setThreads(unsigned char threads)
-    {
-    if (threads > 0)
-        {
-        if  (threads <= 32 && (threads & (threads - 1)) == 0)
-            {
-            m_threads = threads;
-            }
-        else
-            {
-            m_exec_conf->msg->error() << "Threads must be a power of 2 >= 1 and <= 32" << std::endl;
-            throw std::runtime_error("Threads must be a power of 2 >= 1 and <= 32");
-            }
-        }
-    else
-        {
-        m_exec_conf->msg->error() << "Threads must be a power of 2 >= 1 and <= 32" << std::endl;
-        throw std::runtime_error("Threads must be a power of 2 >=1 and <= 32");
-        }
-    }
+template void UniformGridTraverser::traverse(NeighborListOp&,
+                                             const SphereQueryOp&,
+                                             const UniformGrid&,
+                                             const GlobalArray<Scalar3>&,
+                                             cudaStream_t);
 
 } // end namespace neighbor

--- a/neighbor/UniformGridTraverser.cu
+++ b/neighbor/UniformGridTraverser.cu
@@ -4,227 +4,50 @@
 // Maintainer: mphoward
 
 #include "UniformGridTraverser.cuh"
-#include "hoomd/WarpTools.cuh"
+#include "OutputOps.h"
+#include "QueryOps.h"
+#include "TransformOps.h"
 
 namespace neighbor
 {
 namespace gpu
 {
-namespace kernel
-{
 
-//! Kernel to traverse the UniformGrid
-/*!
- * \param d_out Number of primitive intersections per sphere.
- * \param d_spheres Test spheres to intersect with UniformGrid.
- * \param grid UniformGrid to traverse.
- * \param d_stencil Traversal stencil for spheres.
- * \param num_stencil Number of images in the stencil.
- * \param box HOOMD-blue BoxDim for wrapping periodic images.
- * \param N Number of traversal spheres.
- * \tparam threads Number of CUDA threads assigned per sphere.
- *
- * This kernel is based on NeighborListStencilGPU in HOOMD-blue.
- * \a threads CUDA threads are assigned per traversal sphere.
- * They concurrently process each sphere using appropriate warp-level
- * syncrhonization and reduction. The threads advance through the
- * list of stencils, processing primitives from adjacents bins that
- * have not yet been checked. The result is accumulated, and the first
- * thread in each bundle writes the number of intersections to \a d_out.
- * All threads remain active until all have completed their work, at which
- * point they can exit.
- *
- * Intersection tests between the spheres and the points are done in Scalar
- * precision to avoid round off errors and are also subject to the minimum
- * image convention through \a box. This differs from the approach of the
- * LBVH, which traverses images explicitly. This is not a good idea for the
- * UniformGrid because of the overhead in loading new cells and because some
- * images may fall in bins outside the grid.
- */
-template<unsigned int threads>
-__global__ void uniform_grid_traverse(unsigned int *d_out,
-                                      const Scalar4 *d_spheres,
-                                      const UniformGridData grid,
-                                      const int3 *d_stencil,
-                                      const unsigned int num_stencil,
-                                      const BoxDim box,
-                                      const unsigned int N)
-    {
-    // *threads* per primitive
-    const unsigned int tid = blockDim.x * blockIdx.x + threadIdx.x;
-    if (tid >= N*threads)
-        return;
+// template declaration for compressing without transforming primitives
+template void uniform_grid_compress(const UniformGridCompressedData&,
+                                    const NullTransformOp&,
+                                    const UniformGridData&,
+                                    const unsigned int,
+                                    const unsigned int,
+                                    const unsigned int,
+                                    cudaStream_t);
 
-    // load data for the test sphere
-    const unsigned int idx = tid / threads;
-    const Scalar4 sphere = d_spheres[idx];
-    const Scalar3 ri = make_scalar3(sphere.x, sphere.y, sphere.z);
-    const Scalar rcutsq = sphere.w*sphere.w; // assume this is <= stencil radius^2
-    const int3 bin = grid.toCell(ri);
+// template declaration for compressing with map transformation of primitives
+template void uniform_grid_compress(const UniformGridCompressedData&,
+                                    const MapTransformOp&,
+                                    const UniformGridData&,
+                                    const unsigned int,
+                                    const unsigned int,
+                                    const unsigned int,
+                                    cudaStream_t);
 
-    // variables for iterating through with multiple threads
-    unsigned int offset = tid % threads;
-    int s = -1;
-    unsigned int cell = gpu::UniformGridSentinel; // dummy
-    unsigned int first = gpu::UniformGridSentinel; // dummy
-    unsigned int size = 0; // dummy, 0 at first to take first stencil
+// template declaration to count neighbors
+template void uniform_grid_traverse(const CountNeighborsOp& out,
+                                    const UniformGridCompressedData& lbvh,
+                                    const SphereQueryOp& query,
+                                    const Scalar3 *d_images,
+                                    unsigned int Nimages,
+                                    unsigned int block_size,
+                                    cudaStream_t stream);
 
-    bool done = false;
-    unsigned int n_hit = 0;
-    while(!done)
-        {
-        while(offset >= size && !done)
-            {
-            // past end of current cell, move to next stencil
-            offset -= size;
-            ++s;
-
-            // if stencil index is valid
-            if(s < (int)num_stencil)
-                {
-                const int3 stencil = d_stencil[s];
-                const int3 neigh_bin = grid.wrap(make_int3(bin.x+stencil.x, bin.y+stencil.y, bin.z+stencil.z));
-                cell = grid.indexer(neigh_bin.x, neigh_bin.y, neigh_bin.z);
-                size = __ldg(grid.size + cell);
-                if (size > 0) first = __ldg(grid.first + cell);
-                }
-            else
-                {
-                done = true;
-                }
-            }
-
-        // process the point
-        unsigned int primitive = UniformGridSentinel;
-        if (!done)
-            {
-            const Scalar4 neigh = grid.point[first + offset];
-            const Scalar3 rj = make_scalar3(neigh.x, neigh.y, neigh.z);
-
-            const Scalar3 rij = box.minImage(rj - ri);
-            const Scalar dr2 = dot(rij, rij);
-            if (dr2 <= rcutsq)
-                {
-                primitive = __scalar_as_int(neigh.w);
-                }
-
-            offset += threads;
-            }
-
-        // all threads are done if thread 0 is done. otherwise, process the hits
-        if (threads > 1)
-            done = hoomd::detail::WarpScan<bool,threads>().Broadcast(done, 0);
-
-        if (!done)
-            {
-            unsigned char hit = (primitive != UniformGridSentinel);
-            unsigned char k(0), n(hit);
-            if (threads > 1)
-                hoomd::detail::WarpScan<unsigned char, threads>().ExclusiveSum(hit, k, n);
-            n_hit += n;
-            }
-        }
-
-    // only first thread writes out
-    if (tid % threads == 0)
-        {
-        d_out[idx] = n_hit;
-        }
-    }
-
-} // end namespace kernel
-
-//! Helper to clamp the block size of the templated kernel
-/*!
- * \param block_size Requested number of CUDA threads per block.
- * \tparam threads Number of CUDA threads per traversal sphere.
- * \returns The valid number of CUDA threads per block.
- *
- * Each kernel may have different limits on the block size, and so this
- * needs to be computed for each templated parameter. This helper function avoids
- * alot of copy-paste.
- */
-template<unsigned int threads>
-static unsigned int clamp(unsigned int block_size)
-    {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)kernel::uniform_grid_traverse<threads>);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
-    return (block_size < max_block_size) ? block_size : max_block_size;
-    }
-
-/*!
- * \param d_out Number of primitive intersections per sphere.
- * \param d_spheres Test spheres to intersect with UniformGrid.
- * \param grid UniformGrid to traverse.
- * \param d_stencil Traversal stencil for spheres.
- * \param num_stencil Number of images in the stencil.
- * \param box HOOMD-blue BoxDim for wrapping periodic images.
- * \param N Number of traversal spheres.
- * \param threads Number of CUDA threads assigned per sphere.
- * \param block_size Number of CUDA threads per block.
- *
- * \sa kernel::uniform_grid_traverse
- *
- * The appropriate templated invocation of the kernel is selected through a series of
- * if statements. If an invalid \a threads is specified, nothing happens.
- */
-void uniform_grid_traverse(unsigned int *d_out,
-                           const Scalar4 *d_spheres,
-                           const UniformGridData grid,
-                           const int3 *d_stencil,
-                           const unsigned int num_stencil,
-                           const BoxDim& box,
-                           const unsigned int N,
-                           const unsigned int threads,
-                           const unsigned int block_size)
-    {
-    if (threads == 1)
-        {
-        const unsigned int run_block_size = clamp<1>(block_size);
-        const unsigned int num_blocks = (N*threads + run_block_size - 1)/run_block_size;
-        kernel::uniform_grid_traverse<1><<<num_blocks, run_block_size>>>(d_out, d_spheres, grid, d_stencil, num_stencil, box, N);
-        }
-    else if (threads == 2)
-        {
-        const unsigned int run_block_size = clamp<2>(block_size);
-        const unsigned int num_blocks = (N*threads + run_block_size - 1)/run_block_size;
-        kernel::uniform_grid_traverse<2><<<num_blocks, run_block_size>>>(d_out, d_spheres, grid, d_stencil, num_stencil, box, N);
-        }
-    else if (threads == 4)
-        {
-        const unsigned int run_block_size = clamp<4>(block_size);
-        const unsigned int num_blocks = (N*threads + run_block_size - 1)/run_block_size;
-
-        kernel::uniform_grid_traverse<4><<<num_blocks, run_block_size>>>(d_out, d_spheres, grid, d_stencil, num_stencil, box, N);
-        }
-    else if (threads == 8)
-        {
-        const unsigned int run_block_size = clamp<8>(block_size);
-        const unsigned int num_blocks = (N*threads + run_block_size - 1)/run_block_size;
-        kernel::uniform_grid_traverse<8><<<num_blocks, run_block_size>>>(d_out, d_spheres, grid, d_stencil, num_stencil, box, N);
-        }
-    else if (threads == 16)
-        {
-        const unsigned int run_block_size = clamp<16>(block_size);
-        const unsigned int num_blocks = (N*threads + run_block_size - 1)/run_block_size;
-        kernel::uniform_grid_traverse<16><<<num_blocks, run_block_size>>>(d_out, d_spheres, grid, d_stencil, num_stencil, box, N);
-        }
-    else if (threads == 32)
-        {
-        const unsigned int run_block_size = clamp<32>(block_size);
-        const unsigned int num_blocks = (N*threads + run_block_size - 1)/run_block_size;
-        kernel::uniform_grid_traverse<32><<<num_blocks, run_block_size>>>(d_out, d_spheres, grid, d_stencil, num_stencil, box, N);
-        }
-    else
-        {
-        // do nothing
-        }
-    }
+// template declaration to generate neighbor list
+template void uniform_grid_traverse(const NeighborListOp& out,
+                                    const UniformGridCompressedData& lbvh,
+                                    const SphereQueryOp& query,
+                                    const Scalar3 *d_images,
+                                    unsigned int Nimages,
+                                    unsigned int block_size,
+                                    cudaStream_t stream);
 
 } // end namespace gpu
 } // end namespace neighbor

--- a/neighbor/UniformGridTraverser.cuh
+++ b/neighbor/UniformGridTraverser.cuh
@@ -12,8 +12,6 @@
 #include "hoomd/BoxDim.h"
 #include "hoomd/HOOMDMath.h"
 
-#include <stdio.h>
-
 namespace neighbor
 {
 namespace gpu

--- a/neighbor/UniformGridTraverser.cuh
+++ b/neighbor/UniformGridTraverser.cuh
@@ -7,24 +7,275 @@
 #define NEIGHBOR_UNIFORM_GRID_TRAVERSER_CUH_
 
 #include "UniformGrid.cuh"
+#include "BoundingVolumes.h"
+
 #include "hoomd/BoxDim.h"
 #include "hoomd/HOOMDMath.h"
+
+#include <stdio.h>
 
 namespace neighbor
 {
 namespace gpu
 {
 
-//! Traverse the UniformGrid
-void uniform_grid_traverse(unsigned int *d_out,
-                           const Scalar4 *d_spheres,
-                           const UniformGridData grid,
-                           const int3 *d_stencil,
-                           const unsigned int num_stencil,
-                           const BoxDim& box,
+struct UniformGridCompressedData
+    {
+    Scalar4* data;
+    uint2* range;
+    Scalar3 lo;             //!< Lower bound of grid
+    Scalar3 hi;             //!< Upper bound of grid
+    Scalar3 L;              //!< Size of grid
+    Scalar3 width;          //!< Width of bins
+    Index3D indexer;        //!< 3D indexer into the grid memory
+
+    #ifdef NVCC
+    __device__ __forceinline__ int3 toCell(const float3& r) const
+        {
+        // convert position into fraction, then bin
+        const Scalar3 f = make_scalar3(r.x-lo.x, r.y-lo.y, r.z-lo.z)/L;
+        int3 bin = make_int3(static_cast<int>(f.x * indexer.getW()),
+                             static_cast<int>(f.y * indexer.getH()),
+                             static_cast<int>(f.z * indexer.getD()));
+        return bin;
+        }
+    #endif // NVCC
+    };
+
+template<class TransformOpT>
+void uniform_grid_compress(const UniformGridCompressedData& cgrid,
+                           const TransformOpT& transform,
+                           const UniformGridData& grid,
                            const unsigned int N,
-                           const unsigned int threads,
-                           const unsigned int block_size);
+                           const unsigned int Ncell,
+                           const unsigned int block_size,
+                           cudaStream_t stream = 0);
+
+//! Traverse the UniformGrid
+template<class OutputOpT, class QueryOpT>
+void uniform_grid_traverse(const OutputOpT& out,
+                           const UniformGridCompressedData& grid,
+                           const QueryOpT& query,
+                           const Scalar3 *d_images,
+                           unsigned int Nimages,
+                           const unsigned int block_size,
+                           cudaStream_t stream = 0);
+
+#ifdef NVCC
+namespace kernel
+{
+template<class TransformOpT>
+__global__ void uniform_grid_compress(const UniformGridCompressedData cgrid,
+                                      const TransformOpT transform,
+                                      const UniformGridData grid,
+                                      const unsigned int N,
+                                      const unsigned int Ncell)
+    {
+    // one thread per point
+    const unsigned int idx = blockDim.x * blockIdx.x + threadIdx.x;
+
+    // transform primitive data
+    if (idx < N)
+        {
+        // load point and transform the tag
+        Scalar4 p = grid.points[idx];
+        const unsigned int tag = __scalar_as_int(p.w);
+        p.w = __int_as_scalar(transform(tag));
+        cgrid.data[idx] = p;
+        }
+
+    // compress cell data into cache-friendly form
+    if (idx < Ncell)
+        {
+        const unsigned int first = __ldg(grid.first + idx);
+        const unsigned int size = __ldg(grid.size + idx);
+        cgrid.range[idx] = make_uint2(first, first + size);
+        }
+    }
+
+//! Kernel to traverse the UniformGrid
+/*!
+ * \param d_out Number of primitive intersections per sphere.
+ * \param d_spheres Test spheres to intersect with UniformGrid.
+ * \param grid UniformGrid to traverse.
+ * \param d_stencil Traversal stencil for spheres.
+ * \param num_stencil Number of images in the stencil.
+ * \param box HOOMD-blue BoxDim for wrapping periodic images.
+ * \param N Number of traversal spheres.
+ * \tparam threads Number of CUDA threads assigned per sphere.
+ *
+ * This kernel is based on NeighborListStencilGPU in HOOMD-blue.
+ * \a threads CUDA threads are assigned per traversal sphere.
+ * They concurrently process each sphere using appropriate warp-level
+ * syncrhonization and reduction. The threads advance through the
+ * list of stencils, processing primitives from adjacents bins that
+ * have not yet been checked. The result is accumulated, and the first
+ * thread in each bundle writes the number of intersections to \a d_out.
+ * All threads remain active until all have completed their work, at which
+ * point they can exit.
+ *
+ * Intersection tests between the spheres and the points are done in Scalar
+ * precision to avoid round off errors and are also subject to the minimum
+ * image convention through \a box. This differs from the approach of the
+ * LBVH, which traverses images explicitly. This is not a good idea for the
+ * UniformGrid because of the overhead in loading new cells and because some
+ * images may fall in bins outside the grid.
+ */
+template<class OutputOpT, class QueryOpT>
+__global__ void uniform_grid_traverse(const OutputOpT out,
+                                      const UniformGridCompressedData grid,
+                                      const QueryOpT query,
+                                      const Scalar3 *d_images,
+                                      const unsigned int Nimages)
+    {
+    // one thread per test
+    const unsigned int idx = blockDim.x * blockIdx.x + threadIdx.x;
+    if (idx >= query.size())
+        return;
+
+    // load grid size into shared memory
+    __shared__ BoundingBox grid_box;
+    if (threadIdx.x == 0)
+        {
+        grid_box = BoundingBox(grid.lo, grid.hi);
+        }
+    __syncthreads();
+
+    // query thread data
+    const typename QueryOpT::ThreadData qdata = query.setup(idx);
+//     typename OutputOpT::ThreadData result = out.setup(idx, qdata);
+    typename OutputOpT::ThreadData result = out.setup(idx);
+
+    // find image flags against grid box before divergence
+    unsigned int flags = 0;
+    const int nbits = ((int)Nimages <= 32) ? Nimages : 32;
+    for (int i=0; i < nbits; ++i)
+        {
+        const Scalar3 image = d_images[i];
+        const typename QueryOpT::Volume q = query.get(qdata,image);
+        if (query.overlap(q,grid_box)) flags |= 1u << i;
+        }
+
+    // stackless search
+    typename QueryOpT::Volume q = query.get(qdata, make_scalar3(0,0,0));
+    do
+        {
+        // get bin of this bounding box
+        const BoundingBox b = q.asBox();
+
+        // clamp lo to grid
+        int3 lo = grid.toCell(b.lo);
+        if (lo.x < 0) lo.x = 0;
+        if (lo.y < 0) lo.y = 0;
+        if (lo.z < 0) lo.z = 0;
+
+        // clamp hi to grid
+        int3 hi = grid.toCell(b.hi);
+        if (hi.x >= grid.indexer.getW()) hi.x = grid.indexer.getW()-1;
+        if (hi.y >= grid.indexer.getH()) hi.y = grid.indexer.getH()-1;
+        if (hi.z >= grid.indexer.getD()) hi.z = grid.indexer.getD()-1;
+
+        // loop on cells
+        for (int k=lo.z; k <= hi.z; ++k)
+            {
+            for (int j=lo.y; j <= hi.y; ++j)
+                {
+                for (int i=lo.x; i <= hi.x; ++i)
+                    {
+                    const uint2 range = grid.range[grid.indexer(i,j,k)];
+
+                    // loop over primitives
+                    for (unsigned int n=range.x; n < range.y; ++n)
+                        {
+                        const Scalar4 p = grid.data[n];
+                        const Scalar3 r = make_scalar3(p.x, p.y, p.z);
+                        const unsigned int primitive = __scalar_as_int(p.w);
+
+                        if (query.overlap(q, BoundingBox(r,r)))
+                            {
+                            if (query.refine(qdata,primitive))
+                                out.process(result,primitive);
+                            }
+                        }
+                    }
+                }
+            }
+
+        // look for the next image
+        int image_bit = __ffs(flags);
+        if (image_bit)
+            {
+            // shift the lsb by 1 to get the image index
+            --image_bit;
+
+            // move the sphere to the next image
+            const Scalar3 image = d_images[image_bit];
+            q = query.get(qdata, image);
+
+            // unset the bit from this image
+            flags &= ~(1u << image_bit);
+            }
+        else
+            {
+            // no more images, quit
+            break;
+            }
+        } while(true);
+
+    out.finalize(result);
+    }
+} // end namespace kernel
+
+template<class TransformOpT>
+void uniform_grid_compress(const UniformGridCompressedData& cgrid,
+                           const TransformOpT& transform,
+                           const UniformGridData& grid,
+                           const unsigned int N,
+                           const unsigned int Ncell,
+                           const unsigned int block_size,
+                           cudaStream_t stream)
+    {
+    // clamp block size
+    static unsigned int max_block_size = UINT_MAX;
+    if (max_block_size == UINT_MAX)
+        {
+        cudaFuncAttributes attr;
+        cudaFuncGetAttributes(&attr, (const void*)kernel::uniform_grid_compress<TransformOpT>);
+        max_block_size = attr.maxThreadsPerBlock;
+        }
+    const unsigned int run_block_size = (block_size < max_block_size) ? block_size : max_block_size;
+
+    const unsigned int Nthread = (N > Ncell) ? N : Ncell;
+    const unsigned int num_blocks = (Nthread + run_block_size - 1)/run_block_size;
+    kernel::uniform_grid_compress<<<num_blocks, run_block_size, 0, stream>>>
+        (cgrid, transform, grid, N, Ncell);
+    }
+
+//! Traverse the UniformGrid
+template<class OutputOpT, class QueryOpT>
+void uniform_grid_traverse(const OutputOpT& out,
+                           const UniformGridCompressedData& grid,
+                           const QueryOpT& query,
+                           const Scalar3 *d_images,
+                           unsigned int Nimages,
+                           const unsigned int block_size,
+                           cudaStream_t stream)
+    {
+    // clamp block size
+    static unsigned int max_block_size = UINT_MAX;
+    if (max_block_size == UINT_MAX)
+        {
+        cudaFuncAttributes attr;
+        cudaFuncGetAttributes(&attr, (const void*)kernel::uniform_grid_traverse<OutputOpT,QueryOpT>);
+        max_block_size = attr.maxThreadsPerBlock;
+        }
+    const unsigned int run_block_size = (block_size < max_block_size) ? block_size : max_block_size;
+
+    const unsigned int num_blocks = (query.size() + run_block_size - 1)/run_block_size;
+    kernel::uniform_grid_traverse<<<num_blocks, run_block_size, 0, stream>>>
+        (out, grid, query, d_images, Nimages);
+    }
+#endif
 
 } // end namespace gpu
 } // end namespace neighbor

--- a/neighbor/UniformGridTraverser.h
+++ b/neighbor/UniformGridTraverser.h
@@ -7,6 +7,9 @@
 #define NEIGHBOR_UNIFORM_GRID_TRAVERSER_H_
 
 #include "UniformGrid.h"
+#include "UniformGridTraverser.cuh"
+#include "TransformOps.h"
+
 #include "hoomd/BoxDim.h"
 #include "hoomd/ExecutionConfiguration.h"
 #include "hoomd/Autotuner.h"
@@ -35,26 +38,55 @@ class UniformGridTraverser
     {
     public:
         //! Create uniform grid traverser
-        UniformGridTraverser(std::shared_ptr<const ExecutionConfiguration> exec_conf);
-
-        //! Destroy uniform grid traverser
-        virtual ~UniformGridTraverser();
-
-        //! Traverse the uniform grid using the primitives it contains (simple stencil)
-        void traverse(const GlobalArray<unsigned int>& out,
-                      const GlobalArray<Scalar4> spheres,
-                      unsigned int N,
-                      const UniformGrid& grid,
-                      const BoxDim& box);
-
-        //! Get the number of threads per traversal sphere
-        unsigned char getThreads() const
+        UniformGridTraverser(std::shared_ptr<const ExecutionConfiguration> exec_conf)
+            : m_exec_conf(exec_conf), m_replay(false)
             {
-            return m_threads;
+            m_exec_conf->msg->notice(4) << "Constructing UniformGridTraverser" << std::endl;
+
+            m_tune_compress.reset(new Autotuner(32, 1024, 32, 5, 100000, "grid_compress", m_exec_conf));
+            m_tune_traverse.reset(new Autotuner(32, 1024, 32, 5, 100000, "grid_traverse", m_exec_conf));
             }
 
-        //! Set the number of threads per traversal sphere
-        void setThreads(unsigned char threads);
+        //! Destroy uniform grid traverser
+        ~UniformGridTraverser()
+            {
+            m_exec_conf->msg->notice(4) << "Destroying UniformGridTraverser" << std::endl;
+            }
+
+        //! Setup uniform grid for traversal
+        template<class TransformOpT>
+        void setup(const TransformOpT& transform, const UniformGrid& grid, cudaStream_t stream = 0);
+
+        //! Setup uniform grid for traversal
+        void setup(const UniformGrid& grid, cudaStream_t stream = 0)
+            {
+            setup(NullTransformOp(), grid, stream);
+            }
+
+        //! Reset (nullify) the setup
+        void reset()
+            {
+            m_replay = false;
+            }
+
+        //! Traverse the uniform grid
+        template<class OutputOpT, class QueryOpT, class TransformOpT>
+        void traverse(OutputOpT& out,
+                      const QueryOpT& query,
+                      const TransformOpT& transform,
+                      const UniformGrid& grid,
+                      const GlobalArray<Scalar3>& images = GlobalArray<Scalar3>(),
+                      cudaStream_t stream = 0);
+
+        template<class OutputOpT, class QueryOpT>
+        void traverse(OutputOpT& out,
+                      const QueryOpT& query,
+                      const UniformGrid& grid,
+                      const GlobalArray<Scalar3>& images = GlobalArray<Scalar3>(),
+                      cudaStream_t stream = 0)
+            {
+            traverse(out, query, NullTransformOp(), grid, images, stream);
+            }
 
         //! Set the kernel autotuner parameters
         /*!
@@ -63,23 +95,160 @@ class UniformGridTraverser
          */
         void setAutotunerParams(bool enable, unsigned int period)
             {
+            m_tune_compress->setEnabled(enable);
+            m_tune_compress->setPeriod(period);
+
             m_tune_traverse->setEnabled(enable);
             m_tune_traverse->setPeriod(period);
             }
 
-    protected:
+    private:
         std::shared_ptr<const ExecutionConfiguration> m_exec_conf;  //!< Execution configuration
 
-        unsigned char m_threads;    //!< Number of threads per particle
-        unsigned int m_num_stencil; //!< Number of stencils
-        uint3 m_stencil_dim;        //!< Dimension stencil was made for
-        GlobalArray<int3> m_stencil;   //!< Stencil for traversal
+        GlobalArray<Scalar4> m_data;    //!< Internal representation of primitive data
+        GlobalArray<uint2> m_range;     //!< Internal representation of cell ranges
 
+        std::unique_ptr<Autotuner> m_tune_compress; //!< Autotuner for compression kernel
         std::unique_ptr<Autotuner> m_tune_traverse; //!< Autotuner for traversal kernel
 
-        //! Construct the traversal stencil for the grid
-        void createStencil(const UniformGrid& grid);
+        template<class TransformOpT>
+        void compress(const UniformGrid& grid, const TransformOpT& transform, cudaStream_t stream);
+
+        bool m_replay;  //!< If true, the compressed structure has already been set explicitly
     };
+
+/*!
+ * \param transform Transformation operation for cached primitive indexes.
+ * \param grid Grid to traverse.
+ *
+ * \tparam TransformOpT The type of transformation operation.
+ *
+ * This method just calls the compress method on the grid, and marks that this has been done
+ * internally so that subsequent calls to traverse do not compress. This is useful if the same
+ * grid is going to be traversed multiple times. It is the caller's responsibility to ensure
+ * that the transform op and grid do not change between setup and traversal, or the result will
+ * be incorrect.
+ *
+ * To clear a setup, call reset().
+ */
+template<class TransformOpT>
+void UniformGridTraverser::setup(const TransformOpT& transform, const UniformGrid& grid, cudaStream_t stream)
+    {
+    if (grid.getN() == 0) return;
+
+    compress(grid, transform, stream);
+    m_replay = true;
+    }
+
+/*!
+ * \param out Number of overlaps per sphere.
+ * \param spheres Test spheres.
+ * \param N Number of test spheres.
+ * \param grid UniformGrid to traverse.
+ * \param box HOOMD-blue BoxDim corresponding giving the periodicity of the system.
+ *
+ * The format for a \a sphere is (x,y,z,R), where R is the radius of the sphere.
+ *
+ * The caller must ensure that all \a spheres lie within the bounds of the \a grid, or
+ * traversal will produce incorrect results.
+ */
+//! Traverse the uniform grid
+template<class OutputOpT, class QueryOpT, class TransformOpT>
+void UniformGridTraverser::traverse(OutputOpT& out,
+                                    const QueryOpT& query,
+                                    const TransformOpT& transform,
+                                    const UniformGrid& grid,
+                                    const GlobalArray<Scalar3>& images,
+                                    cudaStream_t stream)
+    {
+    // don't traverse empty grid
+    if (grid.getN() == 0) return;
+
+    // kernel uses int32 bitflags for the images, so limit to 32 images
+    const unsigned int Nimages = images.getNumElements();
+    if (Nimages > 32)
+        {
+        m_exec_conf->msg->error() << "A maximum of 32 image vectors are supported by LBVH traversers." << std::endl;
+        throw std::runtime_error("Too many images (>32) in LBVH traverser.");
+        }
+
+    // setup if this is not a replay
+    if (!m_replay)
+        setup(transform, grid, stream);
+
+    // cell list data
+    ArrayHandle<unsigned int> d_first(grid.getFirsts(), access_location::device, access_mode::read);
+    ArrayHandle<unsigned int> d_size(grid.getSizes(), access_location::device, access_mode::read);
+
+    ArrayHandle<Scalar4> d_data(m_data, access_location::device, access_mode::read);
+    ArrayHandle<uint2> d_range(m_range, access_location::device, access_mode::read);
+    // uniform grid data
+    gpu::UniformGridCompressedData g;
+    g.data = d_data.data;
+    g.range = d_range.data;
+    g.lo = grid.getLo();
+    g.hi = grid.getHi();
+    g.L = grid.getL();
+    g.width = grid.getWidth();
+    g.indexer = grid.getIndexer();
+
+    ArrayHandle<Scalar3> d_images(images, access_location::device, access_mode::read);
+
+    m_tune_traverse->begin();
+    gpu::uniform_grid_traverse(out,
+                               g,
+                               query,
+                               d_images.data,
+                               Nimages,
+                               m_tune_traverse->getParam(),
+                               stream);
+    if (m_exec_conf->isCUDAErrorCheckingEnabled()) CHECK_CUDA_ERROR();
+    m_tune_traverse->end();
+    }
+
+template<class TransformOpT>
+void UniformGridTraverser::compress(const UniformGrid& grid, const TransformOpT& transform, cudaStream_t stream)
+    {
+    if (grid.getN() > m_data.getNumElements())
+        {
+        GlobalArray<Scalar4> tmp(grid.getN(), m_exec_conf);
+        m_data.swap(tmp);
+        }
+
+    const unsigned int Ncell = grid.getIndexer().getNumElements();
+    if (Ncell > m_range.getNumElements())
+        {
+        GlobalArray<uint2> tmp(Ncell, m_exec_conf);
+        m_range.swap(tmp);
+        }
+
+    // minimum cell list data to compress / transform (other values are undefined!)
+    ArrayHandle<unsigned int> d_first(grid.getFirsts(), access_location::device, access_mode::read);
+    ArrayHandle<unsigned int> d_size(grid.getSizes(), access_location::device, access_mode::read);
+    ArrayHandle<Scalar4> d_points(grid.getPoints(), access_location::device, access_mode::read);
+    gpu::UniformGridData g;
+    g.first = d_first.data;
+    g.size = d_size.data;
+    g.points = d_points.data;
+
+    // minimum compressed data (other values are undefined!)
+    ArrayHandle<Scalar4> d_data(m_data, access_location::device, access_mode::overwrite);
+    ArrayHandle<uint2> d_range(m_range, access_location::device, access_mode::overwrite);
+    gpu::UniformGridCompressedData cgrid;
+    cgrid.data = d_data.data;
+    cgrid.range = d_range.data;
+
+    m_tune_compress->begin();
+    gpu::uniform_grid_compress(cgrid,
+                               transform,
+                               g,
+                               grid.getN(),
+                               Ncell,
+                               m_tune_compress->getParam(),
+                               stream);
+    if (m_exec_conf->isCUDAErrorCheckingEnabled()) CHECK_CUDA_ERROR();
+    m_tune_compress->end();
+    }
 
 } // end namespace neighbor
 


### PR DESCRIPTION
This PR updates the uniform grid API to mimic the LBVH API. It is not as robust because certain assumptions have to be made about how to insert objects into the grid. Currently, only point insertions are supported. In future, this may be relaxed.