### PR TITLE
add image vector to refine method

### DIFF
--- a/neighbor/LBVHTraverser.cuh
+++ b/neighbor/LBVHTraverser.cuh
@@ -222,7 +222,8 @@ __global__ void lbvh_traverse_ropes(OutputOpT out,
         }
 
     // stackless search
-    typename QueryOpT::Volume q = query.get(qdata, make_scalar3(0,0,0));
+    Scalar3 image = make_scalar3(0,0,0);
+    typename QueryOpT::Volume q = query.get(qdata, image);
     int node = lbvh.root;
     do
         {
@@ -250,7 +251,7 @@ __global__ void lbvh_traverse_ropes(OutputOpT out,
                 if(left < 0)
                     {
                     const int primitive = ~left;
-                    if (query.refine(qdata,primitive))
+                    if (query.refine(qdata,primitive, image))
                         out.process(result,primitive);
                     // leaf nodes always move to their rope
                     }
@@ -270,7 +271,7 @@ __global__ void lbvh_traverse_ropes(OutputOpT out,
             --image_bit;
 
             // move the sphere to the next image
-            const Scalar3 image = d_images[image_bit];
+            image = d_images[image_bit];
             q = query.get(qdata, image);
             node = lbvh.root;
 

--- a/neighbor/QueryOps.h
+++ b/neighbor/QueryOps.h
@@ -100,6 +100,7 @@ struct SphereQueryOp
     /*!
      * \param q Thread data.
      * \param primitive Overlapped primitive.
+     * \param image The current image
      *
      * \returns True if the primitive truly overlaps.
      *
@@ -114,7 +115,7 @@ struct SphereQueryOp
      * In this reference implementation, we do not need any additional refinement, and
      * so we simply return true for all overlapped primitives.
      */
-    DEVICE bool refine(const ThreadData& q, const int primitive) const
+    DEVICE bool refine(const ThreadData& q, const int primitive, const Scalar3& image) const
         {
         return true;
         }

--- a/neighbor/UniformGridTraverser.cuh
+++ b/neighbor/UniformGridTraverser.cuh
@@ -154,7 +154,8 @@ __global__ void uniform_grid_traverse(const OutputOpT out,
         }
 
     // stackless search
-    typename QueryOpT::Volume q = query.get(qdata, make_scalar3(0,0,0));
+    Scalar3 image = make_scalar3(0,0,0);
+    typename QueryOpT::Volume q = query.get(qdata, image);
     do
         {
         // get bin of this bounding box
@@ -190,7 +191,7 @@ __global__ void uniform_grid_traverse(const OutputOpT out,
 
                         if (query.overlap(q, BoundingBox(r,r)))
                             {
-                            if (query.refine(qdata,primitive))
+                            if (query.refine(qdata,primitive, image))
                                 out.process(result,primitive);
                             }
                         }
@@ -206,7 +207,7 @@ __global__ void uniform_grid_traverse(const OutputOpT out,
             --image_bit;
 
             // move the sphere to the next image
-            const Scalar3 image = d_images[image_bit];
+            image = d_images[image_bit];
             q = query.get(qdata, image);
 
             // unset the bit from this image


### PR DESCRIPTION
This fixes an oversight, where the `refine` method of the `ParticleQueryOp` in hoomd required the image vector to work correctly across periodic boundary conditions with diameter shifting. Now we supply it using the traverser.