### PR TITLE
Approximate math header

### DIFF
--- a/include/neighbor/ApproximateMath.h
+++ b/include/neighbor/ApproximateMath.h
@@ -1,0 +1,258 @@
+// Copyright (c) 2018-2019, Michael P. Howard.
+// This file is released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+#ifndef NEIGHBOR_APPROXIMATE_MATH_H_
+#define NEIGHBOR_APPROXIMATE_MATH_H_
+
+#include <cuda_runtime.h>
+
+#define DEVICE __device__ __forceinline__
+
+namespace neighbor
+{
+
+//! Approximate math operations.
+/*!
+ * This namespace defines inline functions that wrap around "approximate" math operations.
+ * Approximate operations are intended to mimic single-precision floating-point math having
+ * different IEEE-754 rounding conventions. These operators are implemented as CUDA intrinsics,
+ * requiring emulation or other names on the host or other architectures.
+ *
+ * In neighbor, we never actually need *exactly* the IEEE-754 result. Instead, we want an fp32
+ * result that is at least below or above this result (and as close as possible) to produce an
+ * efficient, watertight calculation. It is this level of approximation that is guaranteed by
+ * these functions.
+ */
+namespace approx
+{
+//! Convert a double to a float, rounding down.
+/*!
+ * \param x The double to convert.
+ * \return A float that is guaranteed to be below the value of \a x.
+ *
+ * This function guarantees that the returned value will be less than the value of \a x.
+ * It tries to return the closest representable float to \a x that satisfies this condition
+ * without incurring significant overhead.
+ *
+ * On CUDA devices, the conversion is done using a device intrinsic.
+ */
+DEVICE float double2float_rd(double x)
+    {
+    return __double2float_rd(x);
+    }
+
+//! Convert a double to a float, rounding up.
+/*!
+ * \param x The double to convert.
+ * \return A float that is guaranteed to be above the value of \a x.
+ *
+ * This function guarantees that the returned value will be less than the value of \a x.
+ * It tries to return the closest representable float to \a x that satisfies this condition
+ * without incurring significant overhead.
+ *
+ * On CUDA devices, the conversion is done using a device intrinsic.
+ */
+DEVICE float double2float_ru(double x)
+    {
+    return __double2float_ru(x);
+    }
+
+//! Add two floats, rounding the result down.
+/*!
+ * \param x First value.
+ * \param y Second value.
+ * \returns The sum \f$x+y\f$.
+ *
+ * This function guarantees that the resulting sum will be less than or equal to
+ * the IEEE-754 result in round-down mode.
+ *
+ * On CUDA devices, this is exactly satisfied using a device intrinsic.
+ */
+DEVICE float fadd_rd(float x, float y)
+    {
+    return __fadd_rd(x,y);
+    }
+
+//! Add two floats, rounding the result up.
+/*!
+ * \param x First value.
+ * \param y Second value.
+ * \returns The sum \f$x+y\f$.
+ *
+ * This function guarantees that the resulting sum will be greater than or equal to
+ * the IEEE-754 result in round-up mode.
+ *
+ * On CUDA devices, this is exactly satisfied using a device intrinsic.
+ */
+DEVICE float fadd_ru(float x, float y)
+    {
+    return __fadd_ru(x,y);
+    }
+
+//! Subtract two floats, rounding the result down.
+/*!
+ * \param x First value.
+ * \param y Second value.
+ * \returns The difference \f$x-y\f$.
+ *
+ * This function guarantees that the resulting subtraction will be less than or equal to
+ * the IEEE-754 result in round-down mode.
+ *
+ * On CUDA devices, this is exactly satisfied using a device intrinsic.
+ */
+DEVICE float fsub_rd(float x, float y)
+    {
+    return __fsub_rd(x,y);
+    }
+
+//! Subtract two floats, rounding the result up.
+/*!
+ * \param x First value.
+ * \param y Second value.
+ * \returns The difference \f$x-y\f$.
+ *
+ * This function guarantees that the resulting subtraction will be greater than or equal to
+ * the IEEE-754 result in round-up mode.
+ *
+ * On CUDA devices, this is exactly satisfied using a device intrinsic.
+ */
+DEVICE float fsub_ru(float x, float y)
+    {
+    return __fsub_ru(x,y);
+    }
+
+//! Multiply two floats, rounding the result down.
+/*!
+ * \param x First value.
+ * \param y Second value.
+ * \returns The product \f$xy\f$.
+ *
+ * This function guarantees that the resulting product will be less than or equal to
+ * the IEEE-754 result in round-down mode.
+ *
+ * On CUDA devices, this is exactly satisfied using a device intrinsic.
+ */
+DEVICE float fmul_rd(float x, float y)
+    {
+    return __fmul_rd(x,y);
+    }
+
+//! Multiply two floats, rounding the result up.
+/*!
+ * \param x First value.
+ * \param y Second value.
+ * \returns The product \f$xy\f$.
+ *
+ * This function guarantees that the resulting product will be greater than or equal to
+ * the IEEE-754 result in round-up mode.
+ *
+ * On CUDA devices, this is exactly satisfied using a device intrinsic.
+ */
+DEVICE float fmul_ru(float x, float y)
+    {
+    return __fmul_ru(x,y);
+    }
+
+//! Divide two floats, rounding the result down.
+/*!
+ * \param x First value.
+ * \param y Second value.
+ * \returns The product \f$x/y\f$.
+ *
+ * This function guarantees that the resulting quotient will be less than or equal to
+ * the IEEE-754 result in round-down mode.
+ *
+ * On CUDA devices, this is exactly satisfied using a device intrinsic.
+ */
+DEVICE float fdiv_rd(float x, float y)
+    {
+    return __fdiv_rd(x,y);
+    }
+
+//! Divide two floats, rounding the result up.
+/*!
+ * \param x First value.
+ * \param y Second value.
+ * \returns The product \f$x/y\f$.
+ *
+ * This function guarantees that the resulting quotient will be greater than or equal to
+ * the IEEE-754 result in round-up mode.
+ *
+ * On CUDA devices, this is exactly satisfied using a device intrinsic.
+ */
+DEVICE float fdiv_ru(float a, float b)
+    {
+    return __fdiv_ru(a,b);
+    }
+
+//! Take the reciprocal of a float, rounding the result down.
+/*!
+ * \param x Value.
+ * \returns The reciprocal \f$1/x\f$.
+ *
+ * This function guarantees that the resulting reciprocal will be less than or equal to
+ * the IEEE-754 result in round-down mode.
+ *
+ * On CUDA devices, this is exactly satisfied using a device intrinsic.
+ */
+DEVICE float frcp_rd(float x)
+    {
+    return __frcp_rd(x);
+    }
+
+//! Take the reciprocal of a float, rounding the result up.
+/*!
+ * \param x Value.
+ * \returns The reciprocal \f$1/x\f$.
+ *
+ * This function guarantees that the resulting reciprocal will be greater than or equal to
+ * the IEEE-754 result in round-up mode.
+ *
+ * On CUDA devices, this is exactly satisfied using a device intrinsic.
+ */
+DEVICE float frcp_ru(float x)
+    {
+    return __frcp_ru(x);
+    }
+
+//! Fused multiply-add, rounding the result down.
+/*!
+ * \param x First value.
+ * \param y Second value.
+ * \param z Third value.
+ * \returns The single operation \f$xy+z\f$.
+ *
+ * This function guarantees that the resulting value will be less than or equal to
+ * the IEEE-754 result in round-down mode.
+ *
+ * On CUDA devices, this is exactly satisfied using a device intrinsic.
+ */
+DEVICE float fmaf_rd(float x, float y, float z)
+    {
+    return __fmaf_rd(x,y,z);
+    }
+
+//! Fused multiply-add, rounding the result up.
+/*!
+ * \param x First value.
+ * \param y Second value.
+ * \param z Third value.
+ * \returns The single operation \f$xy+z\f$.
+ *
+ * This function guarantees that the resulting value will be greater than or equal to
+ * the IEEE-754 result in round-up mode.
+ *
+ * On CUDA devices, this is exactly satisfied using a device intrinsic.
+ */
+DEVICE float fmaf_ru(float x, float y, float z)
+    {
+    return __fmaf_ru(x,y,z);
+    }
+} // end namespace approx
+} // end namespace neighbor
+
+#undef DEVICE
+
+#endif // NEIGHBOR_APPROXIMATE_MATH_H_

--- a/include/neighbor/BoundingVolumes.h
+++ b/include/neighbor/BoundingVolumes.h
@@ -7,6 +7,7 @@
 #define NEIGHBOR_BOUNDING_VOLUMES_H_
 
 #include <cuda_runtime.h>
+#include "ApproximateMath.h"
 
 namespace neighbor
 {
@@ -53,8 +54,8 @@ struct BoundingBox
      */
     __device__ __forceinline__ BoundingBox(const double3& lo_, const double3& hi_)
         {
-        lo = make_float3(__double2float_rd(lo_.x), __double2float_rd(lo_.y), __double2float_rd(lo_.z));
-        hi = make_float3(__double2float_ru(hi_.x), __double2float_ru(hi_.y), __double2float_ru(hi_.z));
+        lo = make_float3(approx::double2float_rd(lo_.x), approx::double2float_rd(lo_.y), approx::double2float_rd(lo_.z));
+        hi = make_float3(approx::double2float_ru(hi_.x), approx::double2float_ru(hi_.y), approx::double2float_ru(hi_.z));
         }
 
     //! Get the center of the box
@@ -119,7 +120,7 @@ struct BoundingSphere
     __device__ __forceinline__ BoundingSphere(const float3& o, const float r)
         {
         origin = o;
-        Rsq = __fmul_ru(r,r);
+        Rsq = approx::fmul_ru(r,r);
         }
 
     //! Double-precision constructor.
@@ -134,16 +135,16 @@ struct BoundingSphere
      */
     __device__ __forceinline__ BoundingSphere(const double3& o, const double r)
         {
-        const float3 lo = make_float3(__double2float_rd(o.x),
-                                      __double2float_rd(o.y),
-                                      __double2float_rd(o.z));
-        const float3 hi = make_float3(__double2float_ru(o.x),
-                                      __double2float_ru(o.y),
-                                      __double2float_ru(o.z));
-        const float delta = fmaxf(fmaxf(__fsub_ru(hi.x,lo.x),__fsub_ru(hi.y,lo.y)),__fsub_ru(hi.z,lo.z));
-        const float R = __fadd_ru(__double2float_ru(r),delta);
+        const float3 lo = make_float3(approx::double2float_rd(o.x),
+                                      approx::double2float_rd(o.y),
+                                      approx::double2float_rd(o.z));
+        const float3 hi = make_float3(approx::double2float_ru(o.x),
+                                      approx::double2float_ru(o.y),
+                                      approx::double2float_ru(o.z));
+        const float delta = fmaxf(fmaxf(approx::fsub_ru(hi.x,lo.x),approx::fsub_ru(hi.y,lo.y)),approx::fsub_ru(hi.z,lo.z));
+        const float R = approx::fadd_ru(approx::double2float_ru(r),delta);
         origin = make_float3(lo.x, lo.y, lo.z);
-        Rsq = __fmul_ru(R,R);
+        Rsq = approx::fmul_ru(R,R);
         }
 
     //! Test for overlap between a sphere and a BoundingBox.
@@ -162,10 +163,10 @@ struct BoundingSphere
      */
     __device__ __forceinline__ bool overlap(const BoundingBox& box) const
         {
-        const float3 dr = make_float3(__fsub_rd(fminf(fmaxf(origin.x, box.lo.x), box.hi.x), origin.x),
-                                      __fsub_rd(fminf(fmaxf(origin.y, box.lo.y), box.hi.y), origin.y),
-                                      __fsub_rd(fminf(fmaxf(origin.z, box.lo.z), box.hi.z), origin.z));
-        const float dr2 = __fmaf_rd(dr.x, dr.x, __fmaf_rd(dr.y, dr.y, __fmul_rd(dr.z,dr.z)));
+        const float3 dr = make_float3(approx::fsub_rd(fminf(fmaxf(origin.x, box.lo.x), box.hi.x), origin.x),
+                                      approx::fsub_rd(fminf(fmaxf(origin.y, box.lo.y), box.hi.y), origin.y),
+                                      approx::fsub_rd(fminf(fmaxf(origin.z, box.lo.z), box.hi.z), origin.z));
+        const float dr2 = approx::fmaf_rd(dr.x, dr.x, approx::fmaf_rd(dr.y, dr.y, approx::fmul_rd(dr.z,dr.z)));
 
         return (dr2 <= Rsq);
         }

--- a/include/neighbor/kernels/LBVHTraverser.cuh
+++ b/include/neighbor/kernels/LBVHTraverser.cuh
@@ -8,6 +8,7 @@
 
 #include <cuda_runtime.h>
 
+#include "../ApproximateMath.h"
 #include "../LBVHData.h"
 #include "../LBVHTraverserData.h"
 #include "../BoundingVolumes.h"
@@ -59,17 +60,17 @@ __global__ void lbvh_compress_ropes(const LBVHCompressedData ctree,
         tree_lo = tree.lo[tree.root];
         tree_hi = tree.hi[tree.root];
         // compute box size, rounding up to ensure fully covered
-        float3 L = make_float3(__fsub_ru(tree_hi.x, tree_lo.x),
-                               __fsub_ru(tree_hi.y, tree_lo.y),
-                               __fsub_ru(tree_hi.z, tree_lo.z));
+        float3 L = make_float3(approx::fsub_ru(tree_hi.x, tree_lo.x),
+                               approx::fsub_ru(tree_hi.y, tree_lo.y),
+                               approx::fsub_ru(tree_hi.z, tree_lo.z));
         if (L.x <= 0.f) L.x = 1.0f;
         if (L.y <= 0.f) L.y = 1.0f;
         if (L.z <= 0.f) L.z = 1.0f;
 
         // round down the bin scale factor so that it always *underestimates* the offset
-        tree_bininv = make_float3(__fdiv_rd(1023.f,L.x),
-                                  __fdiv_rd(1023.f,L.y),
-                                  __fdiv_rd(1023.f,L.z));
+        tree_bininv = make_float3(approx::fdiv_rd(1023.f,L.x),
+                                  approx::fdiv_rd(1023.f,L.y),
+                                  approx::fdiv_rd(1023.f,L.z));
         }
     __syncthreads();
 
@@ -95,16 +96,16 @@ __global__ void lbvh_compress_ropes(const LBVHCompressedData ctree,
     // compress node data into one byte per box dim
     // low bounds are encoded relative to the low of the box, always rounding down
     const float3 lo = tree.lo[idx];
-    const uint3 lo_bin = make_uint3((unsigned int)floorf(__fmul_rd(__fsub_rd(lo.x,tree_lo.x),tree_bininv.x)),
-                                    (unsigned int)floorf(__fmul_rd(__fsub_rd(lo.y,tree_lo.y),tree_bininv.y)),
-                                    (unsigned int)floorf(__fmul_rd(__fsub_rd(lo.z,tree_lo.z),tree_bininv.z)));
+    const uint3 lo_bin = make_uint3((unsigned int)floorf(approx::fmul_rd(approx::fsub_rd(lo.x,tree_lo.x),tree_bininv.x)),
+                                    (unsigned int)floorf(approx::fmul_rd(approx::fsub_rd(lo.y,tree_lo.y),tree_bininv.y)),
+                                    (unsigned int)floorf(approx::fmul_rd(approx::fsub_rd(lo.z,tree_lo.z),tree_bininv.z)));
     const unsigned int lo_bin3 = (lo_bin.x << 20) +  (lo_bin.y << 10) + lo_bin.z;
 
     // high bounds are encoded relative to the high of the box, always rounding down
     const float3 hi = tree.hi[idx];
-    const uint3 hi_bin = make_uint3((unsigned int)floorf(__fmul_rd(__fsub_rd(tree_hi.x,hi.x),tree_bininv.x)),
-                                    (unsigned int)floorf(__fmul_rd(__fsub_rd(tree_hi.y,hi.y),tree_bininv.y)),
-                                    (unsigned int)floorf(__fmul_rd(__fsub_rd(tree_hi.z,hi.z),tree_bininv.z)));
+    const uint3 hi_bin = make_uint3((unsigned int)floorf(approx::fmul_rd(approx::fsub_rd(tree_hi.x,hi.x),tree_bininv.x)),
+                                    (unsigned int)floorf(approx::fmul_rd(approx::fsub_rd(tree_hi.y,hi.y),tree_bininv.y)),
+                                    (unsigned int)floorf(approx::fmul_rd(approx::fsub_rd(tree_hi.z,hi.z),tree_bininv.z)));
     const unsigned int hi_bin3 = (hi_bin.x << 20) + (hi_bin.y << 10) + hi_bin.z;
 
     // node holds left child for internal nodes (>= 0) or primitive for leaf (< 0)
@@ -118,7 +119,7 @@ __global__ void lbvh_compress_ropes(const LBVHCompressedData ctree,
         {
         *ctree.lo = tree_lo;
         *ctree.hi = tree_hi;
-        *ctree.bins = make_float3(__frcp_rd(tree_bininv.x),__frcp_rd(tree_bininv.y),__frcp_rd(tree_bininv.z));
+        *ctree.bins = make_float3(approx::frcp_rd(tree_bininv.x),approx::frcp_rd(tree_bininv.y),approx::frcp_rd(tree_bininv.z));
         }
     }
 
@@ -214,14 +215,14 @@ __global__ void lbvh_traverse_ropes(const OutputOpT out,
             // load node and decompress bounds so that they always *expand*
             const int4 aabb = __ldg(lbvh.data + node);
             const unsigned int lo = aabb.x;
-            const float3 lof = make_float3(__fadd_rd(tree_box.lo.x, __fmul_rd((lo >> 20) & 0x3ffu,tree_bins.x)),
-                                           __fadd_rd(tree_box.lo.y, __fmul_rd((lo >> 10) & 0x3ffu,tree_bins.y)),
-                                           __fadd_rd(tree_box.lo.z, __fmul_rd((lo      ) & 0x3ffu,tree_bins.z)));
+            const float3 lof = make_float3(approx::fadd_rd(tree_box.lo.x, approx::fmul_rd((lo >> 20) & 0x3ffu,tree_bins.x)),
+                                           approx::fadd_rd(tree_box.lo.y, approx::fmul_rd((lo >> 10) & 0x3ffu,tree_bins.y)),
+                                           approx::fadd_rd(tree_box.lo.z, approx::fmul_rd((lo      ) & 0x3ffu,tree_bins.z)));
 
             const unsigned int hi = aabb.y;
-            const float3 hif = make_float3(__fsub_ru(tree_box.hi.x, __fmul_rd((hi >> 20) & 0x3ffu,tree_bins.x)),
-                                           __fsub_ru(tree_box.hi.y, __fmul_rd((hi >> 10) & 0x3ffu,tree_bins.y)),
-                                           __fsub_ru(tree_box.hi.z, __fmul_rd((hi      ) & 0x3ffu,tree_bins.z)));
+            const float3 hif = make_float3(approx::fsub_ru(tree_box.hi.x, approx::fmul_rd((hi >> 20) & 0x3ffu,tree_bins.x)),
+                                           approx::fsub_ru(tree_box.hi.y, approx::fmul_rd((hi >> 10) & 0x3ffu,tree_bins.y)),
+                                           approx::fsub_ru(tree_box.hi.z, approx::fmul_rd((hi      ) & 0x3ffu,tree_bins.z)));
             const int left = aabb.z;
 
             // advance to rope as a preliminary

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@
 # Maintainer: mphoward
 
 set(TEST_LIST
+    approx_math_test.cu
     lbvh_test.cu
     )
 

--- a/test/approx_math_test.cu
+++ b/test/approx_math_test.cu
@@ -1,0 +1,130 @@
+// Copyright (c) 2018-2019, Michael P. Howard.
+// This file is released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+#include <cuda_runtime.h>
+
+#include "neighbor/neighbor.h"
+
+#include "upp11_config.h"
+UP_MAIN();
+
+//! Kernel to execute math tests (single thread)
+__global__ void approx_math_kernel(float* result)
+    {
+    using namespace neighbor;
+
+    // one thread only
+    const unsigned int idx = blockDim.x * blockIdx.x + threadIdx.x;
+    if (idx != 0)
+        return;
+
+    // casting
+        {
+        const double a = 1.000000000001;
+        result[0] = approx::double2float_rd(a); // = 1.0f
+        result[1] = approx::double2float_ru(a); // > 1.0f
+        result[2] = approx::double2float_rd(-a); // < -1.0f
+        result[3] = approx::double2float_ru(-a); // = -1.0f
+        }
+    // addition
+        {
+        const float a = 1.0f;
+        const float b = 1.e-12f;
+        result[4] = approx::fadd_rd(a,b); // = 1.0f
+        result[5] = approx::fadd_ru(a,b); // > 1.0f
+        result[6] = approx::fadd_rd(-a,-b); // < -1.0f
+        result[7] = approx::fadd_ru(-a,-b); // = -1.0f
+        }
+    // subtraction
+        {
+        const float a = 1.0f;
+        const float b = 1.e-12f;
+        result[8] = approx::fsub_rd(a,b); // < 1.0f
+        result[9] = approx::fsub_ru(a,b); // = 1.0f
+        result[10] = approx::fsub_rd(-a,-b); // = -1.0f
+        result[11] = approx::fsub_ru(-a,-b); // > -1.0f
+        }
+    // multiplication
+        {
+        const float a = 0.1f;
+        const float b = 0.2f;
+        result[12] = approx::fmul_rd(a,b); // = 0.02f
+        result[13] = approx::fmul_ru(a,b); // > 0.02f
+        result[14] = approx::fmul_rd(-a,b); // < -0.02f
+        result[15] = approx::fmul_ru(-a,b);; // = -0.02f
+        }
+    // division
+        {
+        const float a = 1.0f;
+        const float b = 3.0f;
+        result[16] = approx::fdiv_rd(a,b); // < 1.0/3.0
+        result[17] = approx::fdiv_ru(a,b); // > 1.0/3.0
+        result[18] = approx::fdiv_rd(-a,b); // < -1.0/3.0
+        result[19] = approx::fdiv_ru(-a,b); // > -1.0/3.0
+        }
+    // reciprocal
+        {
+        const float a = 3.0f;
+        result[20] = approx::frcp_rd(a); // < 1.0/3.0
+        result[21] = approx::frcp_ru(a); // > 1.0/3.0
+        result[22] = approx::frcp_rd(-a); // < -1.0/3.0
+        result[23] = approx::frcp_ru(-a); // > -1.0/3.0
+        }
+    // fma (just tests basic ops, would be to better to use a real fma)
+        {
+        const float a = 2.0f;
+        const float b = 1.0f;
+        const float c = 1.e-12f;
+        result[24] = approx::fmaf_rd(a,b,c); // = 2.0f
+        result[25] = approx::fmaf_ru(a,b,c); // > 2.0f
+        result[26] = approx::fmaf_rd(-a,b,-c); // < -2.0f
+        result[27] = approx::fmaf_ru(-a,b,-c); // = -2.0f
+        }
+    }
+
+UP_TEST( approx_math_test )
+    {
+    // test the 7 functions in ApproximateMath.h in round down and round up modes, 2 tests each
+    neighbor::shared_array<float> result(7*2*2);
+
+    approx_math_kernel<<<1,1>>>(result.get());
+    cudaDeviceSynchronize();
+
+    // casting
+    UP_ASSERT_EQUAL(result[0], 1.0f);
+    UP_ASSERT_GREATER(result[1], 1.0f);
+    UP_ASSERT_LESS(result[2], -1.0f);
+    UP_ASSERT_EQUAL(result[3], -1.0f);
+    // addition
+    UP_ASSERT_EQUAL(result[4], 1.0f);
+    UP_ASSERT_GREATER(result[5], 1.0f);
+    UP_ASSERT_LESS(result[6], -1.0f);
+    UP_ASSERT_EQUAL(result[7], -1.0f);
+    // subtraction
+    UP_ASSERT_LESS(result[8], 1.0f);
+    UP_ASSERT_EQUAL(result[9], 1.0f);
+    UP_ASSERT_EQUAL(result[10], -1.0f);
+    UP_ASSERT_GREATER(result[11], -1.0f);
+    // multiplication
+    UP_ASSERT_EQUAL(result[12], 0.02f);
+    UP_ASSERT_GREATER(result[13], 0.02f);
+    UP_ASSERT_LESS(result[14], -0.02f);
+    UP_ASSERT_EQUAL(result[15], -0.02f);
+    // division (loose test)
+    UP_ASSERT_LESS(result[16], 1.0/3.0);
+    UP_ASSERT_GREATER(result[17], 1.0/3.0);
+    UP_ASSERT_LESS(result[18], -1.0/3.0);
+    UP_ASSERT_GREATER(result[19], -1.0/3.0);
+    // reciprocal (loose test)
+    UP_ASSERT_LESS(result[20], 1.0/3.0);
+    UP_ASSERT_GREATER(result[21], 1.0/3.0);
+    UP_ASSERT_LESS(result[22], -1.0/3.0);
+    UP_ASSERT_GREATER(result[23], -1.0/3.0);
+    // fma
+    UP_ASSERT_EQUAL(result[24], 2.0f);
+    UP_ASSERT_GREATER(result[25], 2.0f);
+    UP_ASSERT_LESS(result[26], -2.0f);
+    UP_ASSERT_EQUAL(result[27], -2.0f);
+    }


### PR DESCRIPTION
This adds a header wrapping the CUDA device intrinsics so that alternative versions can be implemented.

For example, we could define host versions that first do the operation in float and then take `nextafter` in the appropriate direction. This guarantees that we will either get exactly the same result as the one returned by the CUDA intrinsic, or the next representable float value after it. This is close enough of an approximation.

Should be merged after PR #9 and will help with PR #7.